### PR TITLE
Add golfers scores page

### DIFF
--- a/lib/useUserScores.js
+++ b/lib/useUserScores.js
@@ -2,7 +2,7 @@ import { getToken } from "./userAuth"
 import useSWR from 'swr'
 
 const useUserScores = id => {
-  const user_scores_url = `${process.env.NEXT_PUBLIC_API_URL}/user/${id}`
+  const user_scores_url = `${process.env.NEXT_PUBLIC_API_URL}/user/scores/${id}`
 
   const fetcher = async url => {
     const res = await fetch(url, {

--- a/lib/useUserScores.js
+++ b/lib/useUserScores.js
@@ -2,7 +2,7 @@ import { getToken } from "./userAuth"
 import useSWR from 'swr'
 
 const useUserScores = id => {
-  const user_scores_url = `${process.env.NEXT_PUBLIC_API_URL}/user/scores/${id}`
+  const user_scores_url = `${process.env.NEXT_PUBLIC_API_URL}/users/${id}`
 
   const fetcher = async url => {
     const res = await fetch(url, {

--- a/lib/useUserScores.js
+++ b/lib/useUserScores.js
@@ -1,0 +1,32 @@
+import { getToken } from "./userAuth"
+import useSWR from 'swr'
+
+const useUserScores = id => {
+  const user_scores_url = `${process.env.NEXT_PUBLIC_API_URL}/user/${id}`
+
+  const fetcher = async url => {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${getToken()}`
+      }
+    })
+
+    if (!res.ok) {
+      const error = new Error('An error occured while fetching the data')
+      error.info = await res.json()
+      error.status = res.status
+      throw error
+    }
+    return res.json().then(data => data.user)
+  }
+
+  const { data, error } = useSWR(user_scores_url, fetcher)
+
+  return {
+    data,
+    error: error
+  }
+}
+
+export default useUserScores 

--- a/pages/golfers/[id]/index.js
+++ b/pages/golfers/[id]/index.js
@@ -1,0 +1,40 @@
+import { useRouter } from "next/router"
+import useUserScores from "../../../lib/useUserScores"
+import ScoreCard from '../../../components/ScoreCard'
+import Layout from "../../../components/Layout"
+
+const Golfers = () => {
+  const router = useRouter()
+  const { id } = router.query
+  const { data, error } = useUserScores(id)
+
+  const filteredScores = data?.scores?.map(score => (
+    <ScoreCard
+      key={score.id}
+      id={score.id}
+      totalScore={score.total_score}
+      playedAt={score.played_at}
+      userId={score.user_id}
+      userName={data.name}
+    />
+   ))
+
+  return (
+    <Layout>
+      <>
+        {error ? (
+          <>
+          {`${error.info.errors}`}
+          </>
+        ) : (
+          <>
+            <h1>{`GOLFER: ${data?.name}`}</h1>
+            {data?.scores && filteredScores}
+          </>
+        )}
+      </>
+    </Layout>
+  )
+}
+
+export default Golfers 


### PR DESCRIPTION
Fixes: [Adding golfers score page](https://github.com/GeorgeMarcus/golfr_frontend/issues/1) 

**Changes**
Added golfers page, showing users scores. Access: < env >/golfers/:id

**Before**
The page couldn't be accessed:
<img width="684" alt="Screenshot 2022-08-03 at 10 09 40" src="https://user-images.githubusercontent.com/108520650/182546297-52147ed9-4a9a-4d2f-99cc-0ca5a970a57b.png">


**After**
case valid :id : The page shows the name of the golfer and its scores
<img width="537" alt="Screenshot 2022-08-03 at 09 59 59" src="https://user-images.githubusercontent.com/108520650/182544640-c7cf7330-7ef6-4d54-90ae-f432b68e550f.png">

case invalid :id : Error message
<img width="353" alt="Screenshot 2022-08-03 at 10 10 22" src="https://user-images.githubusercontent.com/108520650/182546465-dbaa498f-4abd-43c3-b295-e65d9abf306b.png">


